### PR TITLE
가게, 카테고리, 엔티티 구현하기

### DIFF
--- a/src/main/java/com/spring/mySelectShop/domain/category/entity/Category.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/entity/Category.java
@@ -1,0 +1,34 @@
+package com.spring.mySelectShop.domain.category.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "category_id", unique = true, nullable = false)
+    private UUID id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "is_active")
+    private Boolean isActive;
+
+    @OneToMany(mappedBy = "category")
+    private List<Category> categories = new ArrayList<>();
+}

--- a/src/main/java/com/spring/mySelectShop/domain/store/entity/Store.java
+++ b/src/main/java/com/spring/mySelectShop/domain/store/entity/Store.java
@@ -1,0 +1,49 @@
+package com.spring.mySelectShop.domain.store.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Store {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "store_id", unique = true, nullable = false)
+    private UUID id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "address", nullable = false)
+    private String address;
+
+    @Column(name = "phone", nullable = false)
+    private String phone;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+
+    @Column(name = "minimum_price", nullable = false)
+    private Integer minimum_price;
+
+    @Column(name = "delivery_price", nullable = false)
+    private Integer delivery_price;
+
+    @Column(name = "rating", nullable = false)
+    private Float rating;
+
+    @OneToMany(mappedBy = "store")
+    private List<StoreCategory> storeCategories = new ArrayList<StoreCategory>();
+}

--- a/src/main/java/com/spring/mySelectShop/domain/store/entity/StoreCategory.java
+++ b/src/main/java/com/spring/mySelectShop/domain/store/entity/StoreCategory.java
@@ -1,0 +1,36 @@
+package com.spring.mySelectShop.domain.store.entity;
+
+import com.spring.mySelectShop.domain.category.entity.Category;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class StoreCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String name;
+
+    private Boolean isActive;
+
+    @ManyToOne
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+}


### PR DESCRIPTION
## ✨ 작업 내용
- [x] 이슈 번호: This closes #4 
- [x] 주요 변경 사항을 간략히 설명
가게, 가게카테고리, 카테고리를 추가한다.

✔ 결론: StoreCategory는 가게(Store) 입장에서 카테고리를 관리하는 서브 도메인 역할을 하기 때문!
✔ 즉, StoreCategory는 독립적인 개념이라기보다, "가게가 어떤 카테고리에 속하는지"를 정의하는 엔티티이므로 store 패키지 내부에서 관리하는 것이 더 자연스러움.

1. StoreCategory는 가게의 하위 개념
📌 왜 StoreCategory를 store 패키지에 넣는가?
StoreCategory는 가게(Store)를 기준으로 카테고리를 매핑하는 엔티티
Category 자체는 독립적인 엔티티이지만, StoreCategory는 **"가게(Store)와 연결된 카테고리"**를 정의하는 서브 도메인
즉, StoreCategory는 **"가게(Store) 관점에서 카테고리를 연결하는 역할"**을 수행
📌 따라서 StoreCategory는 store 패키지에서 관리하는 것이 적절!

 만약 StoreCategory를 category 패키지에 넣는다면? (잘못된 방식 🚫)
- Category와 연관성이 강조됨
- StoreCategory는 Store와 강한 연관이 있음에도 category에서 관리되어 책임이 모호해짐
- Store 관련 로직에서 category 패키지를 참조해야 하므로 종속성이 증가

📌 즉, StoreCategory는 store 입장에서 관리하는 개념이므로 store 패키지에서 관리하는 것이 유지보수와 확장성 측면에서 더 적절함! 🚀

## 🛠 변경 사항
- [x] 기능 추가 / 수정 / 삭제 설명
- [x] 기존 코드에서 변경된 사항 (가능하면 코드 블록 활용)

## 🔍 테스트 방법
- [x] 테스트 시나리오 작성 (어떻게 테스트했는지 설명)

## ✅ 체크리스트
- [x] PR 제목이 명확한지 확인
- [x] 코드 스타일 및 포맷팅이 맞는지 확인
- [x] 필요한 경우, 문서(README) 업데이트

## 📸 스크린샷 (선택)
(기능이 UI와 관련되어 있다면 스크린샷 첨부!)

## 🤔 추가 논의 사항 (선택)
- (리뷰어에게 논의가 필요한 부분이 있다면 작성!)