### PR TITLE
카테고리 등록/수정/삭제 구현하기

### DIFF
--- a/src/main/java/com/spring/mySelectShop/MySelectShopApplication.java
+++ b/src/main/java/com/spring/mySelectShop/MySelectShopApplication.java
@@ -2,8 +2,11 @@ package com.spring.mySelectShop;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
 
 @SpringBootApplication
+@EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)
 public class MySelectShopApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/spring/mySelectShop/common/excepetion/GlobalExceptionCode.java
+++ b/src/main/java/com/spring/mySelectShop/common/excepetion/GlobalExceptionCode.java
@@ -1,0 +1,44 @@
+package com.spring.mySelectShop.common.excepetion;
+
+import com.spring.mySelectShop.common.response.ResponseCodeInterface;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * MSA 확장성을 고려한 글로벌 예외 코드 Enum
+ */
+@RequiredArgsConstructor
+@Getter
+public enum GlobalExceptionCode implements ResponseCodeInterface {
+    // 1xxx: 잘못된 요청 관련 예외
+    INVALID_REQUEST(1001, "잘못된 요청입니다."),
+    MISSING_REQUEST_PARAMETER(1002, "필수 요청 파라미터가 누락되었습니다."),
+    UNSUPPORTED_MEDIA_TYPE(1003, "지원되지 않는 미디어 타입입니다."),
+
+    // 2xxx: 인증 및 인가 관련 예외
+    UNAUTHORIZED(2001, "인증이 필요합니다."),
+    FORBIDDEN(2002, "권한이 없습니다."),
+    ACCESS_DENIED(2003, "접근이 거부되었습니다."),
+    TOKEN_EXPIRED(2004, "토큰이 만료되었습니다."),
+    INVALID_TOKEN(2005, "유효하지 않은 토큰입니다."),
+
+    // 3xxx: 데이터 관련 예외
+    DATA_NOT_FOUND(3001, "요청한 데이터를 찾을 수 없습니다."),
+    DUPLICATE_RESOURCE(3002, "이미 존재하는 데이터입니다."),
+    DATABASE_ERROR(3003, "데이터베이스 오류가 발생했습니다."),
+    DATA_INTEGRITY_VIOLATION(3004, "데이터 무결성 제약 조건을 위반했습니다."),
+
+    // 4xxx: 서버 오류 관련 예외
+    INTERNAL_SERVER_ERROR(4001, "서버 내부 오류가 발생했습니다."),
+    SERVICE_UNAVAILABLE(4002, "현재 서비스를 사용할 수 없습니다."),
+    TIMEOUT_ERROR(4003, "요청 시간이 초과되었습니다."),
+    EXTERNAL_SERVICE_ERROR(4004, "외부 서비스 연동 중 오류가 발생했습니다."),
+
+    // 5xxx: 파일 처리 및 기타 예외
+    FILE_UPLOAD_FAILED(5001, "파일 업로드에 실패했습니다."),
+    FILE_NOT_FOUND(5002, "요청한 파일을 찾을 수 없습니다."),
+    UNSUPPORTED_FILE_TYPE(5003, "지원되지 않는 파일 형식입니다.");
+
+    private final Integer code;
+    private final String message;
+}

--- a/src/main/java/com/spring/mySelectShop/common/excepetion/GlobalExceptionHandler.java
+++ b/src/main/java/com/spring/mySelectShop/common/excepetion/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.spring.mySelectShop.common.excepetion;
+
+import com.spring.mySelectShop.common.response.ErrorResponse;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Order(2)
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleGlobalException(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(
+                        new ErrorResponse(
+                                GlobalExceptionCode.INTERNAL_SERVER_ERROR,
+                                "서버 내부 오류가 발생했습니다."
+                        )
+                );
+    }
+}

--- a/src/main/java/com/spring/mySelectShop/common/response/ErrorResponse.java
+++ b/src/main/java/com/spring/mySelectShop/common/response/ErrorResponse.java
@@ -1,0 +1,52 @@
+package com.spring.mySelectShop.common.response;
+
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse implements ResponseCodeInterface {
+
+    private final Integer code;
+    private final String message;
+    private final String serviceName;
+
+    public ErrorResponse(Integer code, String message, String serviceName) {
+        this.code = code;
+        this.message = message;
+        this.serviceName = serviceName;
+    }
+
+    public ErrorResponse(ResponseCodeInterface responseCode, String serviceName) {
+        this(responseCode.getCode(), responseCode.getMessage(), serviceName);
+    }
+
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        var that = (ErrorResponse) obj;
+        return Objects.equals(this.code, that.code) &&
+                Objects.equals(this.message, that.message) &&
+                Objects.equals(this.serviceName, that.serviceName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, message, serviceName);
+    }
+
+    @Override
+    public String toString() {
+        return "ErrorResponse[" +
+                "code=" + code + ", " +
+                "message=" + message + ", " +
+                "serviceName=" + serviceName + ']';
+    }
+
+}
+

--- a/src/main/java/com/spring/mySelectShop/common/response/HttpResponse.java
+++ b/src/main/java/com/spring/mySelectShop/common/response/HttpResponse.java
@@ -1,0 +1,63 @@
+package com.spring.mySelectShop.common.response;
+
+import java.util.Objects;
+import lombok.Getter;
+
+/**
+ *
+ */
+@Getter
+public class HttpResponse<T> implements ResponseCodeInterface {
+
+    private final Integer code;
+    private final String message;
+    private final T data;
+
+    /**
+     * 
+     * @param code: 응답 코드
+     * @param message: 메시지
+     * @param data: 데이터
+     */
+    public HttpResponse(
+            Integer code,
+            String message,
+            T data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public HttpResponse(ResponseCodeInterface responseCode, T data) {
+        this(responseCode.getCode(), responseCode.getMessage(), data);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        var that = (HttpResponse) obj;
+        return Objects.equals(this.code, that.code) &&
+                Objects.equals(this.message, that.message) &&
+                Objects.equals(this.data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, message, data);
+    }
+
+    @Override
+    public String toString() {
+        return "HttpResponse[" +
+                "code=" + code + ", " +
+                "message=" + message + ", " +
+                "data=" + data + ", " +
+                ']';
+    }
+
+}

--- a/src/main/java/com/spring/mySelectShop/common/response/ResponseCodeInterface.java
+++ b/src/main/java/com/spring/mySelectShop/common/response/ResponseCodeInterface.java
@@ -1,0 +1,6 @@
+package com.spring.mySelectShop.common.response;
+
+public interface ResponseCodeInterface {
+    Integer getCode();
+    String getMessage();
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/controller/CategoryController.java
@@ -1,0 +1,79 @@
+package com.spring.mySelectShop.domain.category.controller;
+
+import static com.spring.mySelectShop.domain.category.dto.CategoryResponseCode.CATEGORY_CREATED;
+import static com.spring.mySelectShop.domain.category.dto.CategoryResponseCode.CATEGORY_FETCHED;
+
+import com.spring.mySelectShop.common.response.HttpResponse;
+import com.spring.mySelectShop.domain.category.dto.CategoryDto;
+import com.spring.mySelectShop.domain.category.dto.CategoryResponseCode;
+import com.spring.mySelectShop.domain.category.dto.request.CreateCategoryRequestDto;
+import com.spring.mySelectShop.domain.category.dto.request.UpdateCategoryRequestDto;
+import com.spring.mySelectShop.domain.category.service.CategoryService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/category")
+@RestController
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @PostMapping
+    public ResponseEntity<HttpResponse<CategoryDto>> createCategory(
+            @RequestBody @Valid CreateCategoryRequestDto requestDto) {
+        return new ResponseEntity<>(
+                new HttpResponse<>(CATEGORY_CREATED,
+                        categoryService.createCategory(requestDto)),
+                HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<HttpResponse<Page<CategoryDto>>> getAllCategories(
+            @RequestParam("page") Integer page,
+            @RequestParam("size") Integer size,
+            @RequestParam("sortBy") String sortBy,
+            @RequestParam("isAsc") Boolean isAsc) {
+
+        return ResponseEntity.ok(new HttpResponse<>(CategoryResponseCode.CATEGORIES_FETCHED,
+                categoryService.getAllActiveCategories(page - 1, size, sortBy, isAsc)
+        ));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<HttpResponse<CategoryDto>> getCategoryById(@PathVariable UUID id) {
+        return new ResponseEntity<>(
+                new HttpResponse<>(CATEGORY_FETCHED, categoryService.getCategoryById(id)),
+                HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<HttpResponse<CategoryDto>> deleteCategoryById(@PathVariable UUID id) {
+        return new ResponseEntity<>(
+                new HttpResponse<>(CategoryResponseCode.CATEGORY_DELETED,
+                        categoryService.deleteCategoryById(id)),
+                HttpStatus.OK);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<HttpResponse<CategoryDto>> updateCategoryByName(@PathVariable UUID id,
+            @RequestBody UpdateCategoryRequestDto requestDto) {
+        return new ResponseEntity<>(
+                new HttpResponse<>(CategoryResponseCode.CATEGORY_UPDATED,
+                        categoryService.updateCategoryByName(id, requestDto)),
+                HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/dto/CategoryDto.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/dto/CategoryDto.java
@@ -1,0 +1,27 @@
+package com.spring.mySelectShop.domain.category.dto;
+
+import static com.spring.mySelectShop.domain.category.entity.Category.*;
+
+import com.spring.mySelectShop.domain.category.entity.Category;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public record CategoryDto(
+        UUID id,
+        String name,
+        Boolean isActive
+) {
+
+    public static CategoryDto fromEntity(Category category) {
+        return new CategoryDto(category.getId(), category.getName(), category.getIsActive());
+    }
+
+    public static List<CategoryDto> fromEntities(List<Category> categories) {
+        return categories.stream().map(CategoryDto::fromEntity).collect(Collectors.toList());
+    }
+
+    public Category toEntity() { // 새로운 데이터 생성(ID 없음)
+        return create(name, isActive);
+    }
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/dto/CategoryResponseCode.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/dto/CategoryResponseCode.java
@@ -1,0 +1,21 @@
+package com.spring.mySelectShop.domain.category.dto;
+
+import com.spring.mySelectShop.common.response.ResponseCodeInterface;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum CategoryResponseCode implements ResponseCodeInterface {
+    SUCCESS(1000, "요청이 성공적으로 처리되었습니다."),
+    FAILURE(1001, "요청 처리에 실패했습니다."),
+
+    CATEGORY_CREATED(2001, "카테고리 등록에 성공했습니다."),
+    CATEGORY_UPDATED(2002, "카테고리 정보가 수정되었습니다."),
+    CATEGORY_DELETED(2003, "카테고리가 삭제되었습니다."),
+    CATEGORY_FETCHED(2004, "카테고리 정보를 성공적으로 조회했습니다."),
+    CATEGORIES_FETCHED(2005, "전체 카테고리 목록을 성공적으로 조회했습니다.");
+
+    private final Integer code;
+    private final String message;
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/dto/CategoryValidationMessages.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/dto/CategoryValidationMessages.java
@@ -1,0 +1,10 @@
+package com.spring.mySelectShop.domain.category.dto;
+
+public class CategoryValidationMessages {
+
+    public static final String CATEGORY_NAME_BLANK = "카테고리 이름: 필수 정보입니다.";
+    public static final String CATEGORY_NAME_INVALID = "카테고리 이름은 한글, 숫자, 특수 문자(·, !), 공백만 입력 가능하며, 1~16글자 이내여야 합니다.";
+    public static final String CATEGORY_IS_ACTIVE_BLANK = "카테고리 활성화 여부: 필수 정보 입니다.";
+
+
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/dto/request/CreateCategoryRequestDto.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/dto/request/CreateCategoryRequestDto.java
@@ -1,0 +1,24 @@
+package com.spring.mySelectShop.domain.category.dto.request;
+
+import static com.spring.mySelectShop.domain.category.dto.CategoryValidationMessages.CATEGORY_IS_ACTIVE_BLANK;
+import static com.spring.mySelectShop.domain.category.dto.CategoryValidationMessages.CATEGORY_NAME_BLANK;
+import static com.spring.mySelectShop.domain.category.dto.CategoryValidationMessages.CATEGORY_NAME_INVALID;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record CreateCategoryRequestDto(
+
+        @NotBlank(message = CATEGORY_NAME_BLANK)
+        @Pattern(
+                regexp = "^[가-힣0-9·!\\s]{1,16}$",
+                message = CATEGORY_NAME_INVALID
+        )
+        String name,
+
+        @NotNull(message = CATEGORY_IS_ACTIVE_BLANK)
+        Boolean isActive
+) {
+
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/dto/request/UpdateCategoryRequestDto.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/dto/request/UpdateCategoryRequestDto.java
@@ -1,0 +1,16 @@
+package com.spring.mySelectShop.domain.category.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+
+public record UpdateCategoryRequestDto(
+
+        @NotBlank(message = "카테고리 이름: 필수 정보입니다.")
+        @Pattern(
+                regexp = "^[가-힣0-9·!\\s]{1,16}$",
+                message = "카테고리 이름은 한글, 숫자, 특수 문자(·, !), 공백만 입력 가능하며, 1~16글자 이내여야 합니다."
+        )
+        String name
+) {
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/entity/Category.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/entity/Category.java
@@ -1,5 +1,7 @@
 package com.spring.mySelectShop.domain.category.entity;
 
+import com.spring.mySelectShop.domain.store.entity.StoreCategory;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -11,24 +13,43 @@ import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
-@AllArgsConstructor
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Category {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "category_id", unique = true, nullable = false)
+    @Column(name = "category_id", nullable = false, unique = true)
     private UUID id;
 
-    @Column(name = "name")
+    @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "is_active")
-    private Boolean isActive;
+    @Column(name = "is_active", nullable = false)
+    @ColumnDefault("true")
+    private Boolean isActive = true;
 
-    @OneToMany(mappedBy = "category")
-    private List<Category> categories = new ArrayList<>();
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<StoreCategory> storeCategories = new ArrayList<>();
+
+    private Category(String name, Boolean isActive) {
+        this.name = name;
+        this.isActive = isActive != null ? isActive : Boolean.TRUE;
+    }
+
+    public static Category create(String name, Boolean isActive) {
+        return new Category(name, isActive);
+    }
+
+    public void update(String name, Boolean isActive) {
+        this.name = name;
+        this.isActive = isActive != null ? isActive : this.isActive;
+    }
+
+
 }

--- a/src/main/java/com/spring/mySelectShop/domain/category/exception/CategoryExceptionCode.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/exception/CategoryExceptionCode.java
@@ -1,0 +1,19 @@
+package com.spring.mySelectShop.domain.category.exception;
+
+import com.spring.mySelectShop.common.response.ResponseCodeInterface;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum CategoryExceptionCode implements ResponseCodeInterface {
+    CATEGORY_NOT_FOUND(6001, "해당 카테고리를 찾을 수 없습니다."),
+    CATEGORY_ALREADY_EXISTS(6002, "이미 존재하는 카테고리입니다."),
+    CATEGORY_UPDATE_FAILED(6003, "카테고리 업데이트에 실패했습니다."),
+    CATEGORY_DELETE_FAILED(6004, "카테고리 삭제에 실패했습니다."),
+    CATEGORY_NAME_INVALID(6005, "카테고리 이름이 유효하지 않습니다."),
+    CATEGORY_IS_ACTIVE_INVALID(6006, "카테고리 활성화 여부가 유효하지 않습니다.");
+
+    private final Integer code;
+    private final String message;
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/exception/CategoryExceptionHandler.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/exception/CategoryExceptionHandler.java
@@ -1,0 +1,51 @@
+package com.spring.mySelectShop.domain.category.exception;
+
+import com.spring.mySelectShop.common.response.HttpResponse;
+import com.spring.mySelectShop.domain.category.dto.CategoryDto;
+import com.spring.mySelectShop.domain.category.exception.custom.CategoryAlreadyExistsException;
+import com.spring.mySelectShop.domain.category.exception.custom.CategoryIsActiveBlankException;
+import com.spring.mySelectShop.domain.category.exception.custom.CategoryNameInvalidException;
+import com.spring.mySelectShop.domain.category.exception.custom.CategoryNotFoundException;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 카테고리 도메인 전용 예외 처리 핸들러
+ */
+@Order(1)
+@RestControllerAdvice
+public class CategoryExceptionHandler {
+
+    @ExceptionHandler(CategoryNotFoundException.class)
+    public ResponseEntity<HttpResponse<Void>> categoryNotFound(CategoryNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                new HttpResponse<>(CategoryExceptionCode.CATEGORY_NOT_FOUND, null)
+        );
+    }
+
+
+    @ExceptionHandler(CategoryNameInvalidException.class)
+    public ResponseEntity<HttpResponse<CategoryDto>> categoryNameInvalid(CategoryNameInvalidException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                new HttpResponse<>(CategoryExceptionCode.CATEGORY_NAME_INVALID, null)
+        );
+    }
+
+    @ExceptionHandler(CategoryIsActiveBlankException.class)
+    public ResponseEntity<HttpResponse<CategoryDto>> categoryIsActiveBlank(CategoryIsActiveBlankException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                new HttpResponse<>(CategoryExceptionCode.CATEGORY_IS_ACTIVE_INVALID, null)
+        );
+    }
+
+    @ExceptionHandler(CategoryAlreadyExistsException.class)
+    public ResponseEntity<HttpResponse<Void>> categoryAlreadyExists(CategoryAlreadyExistsException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                new HttpResponse<>(CategoryExceptionCode.CATEGORY_ALREADY_EXISTS, null)
+        );
+    }
+
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/exception/custom/CategoryAlreadyExistsException.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/exception/custom/CategoryAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.spring.mySelectShop.domain.category.exception.custom;
+
+public class CategoryAlreadyExistsException extends RuntimeException {
+
+    public CategoryAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/exception/custom/CategoryIsActiveBlankException.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/exception/custom/CategoryIsActiveBlankException.java
@@ -1,0 +1,8 @@
+package com.spring.mySelectShop.domain.category.exception.custom;
+
+public class CategoryIsActiveBlankException extends RuntimeException {
+
+    public CategoryIsActiveBlankException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/exception/custom/CategoryNameInvalidException.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/exception/custom/CategoryNameInvalidException.java
@@ -1,0 +1,8 @@
+package com.spring.mySelectShop.domain.category.exception.custom;
+
+public class CategoryNameInvalidException extends RuntimeException {
+
+    public CategoryNameInvalidException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/exception/custom/CategoryNotFoundException.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/exception/custom/CategoryNotFoundException.java
@@ -1,0 +1,7 @@
+package com.spring.mySelectShop.domain.category.exception.custom;
+
+public class CategoryNotFoundException extends RuntimeException  {
+    public CategoryNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,16 @@
+package com.spring.mySelectShop.domain.category.repository;
+
+import com.spring.mySelectShop.domain.category.entity.Category;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CategoryRepository extends JpaRepository<Category, UUID> {
+
+    Page<Category> findAllByIsActiveTrue(Pageable pageable);
+    Boolean existsByName(String name);
+}

--- a/src/main/java/com/spring/mySelectShop/domain/category/service/CategoryService.java
+++ b/src/main/java/com/spring/mySelectShop/domain/category/service/CategoryService.java
@@ -1,0 +1,86 @@
+package com.spring.mySelectShop.domain.category.service;
+
+import static com.spring.mySelectShop.domain.category.entity.Category.create;
+
+import com.spring.mySelectShop.domain.category.dto.CategoryDto;
+import com.spring.mySelectShop.domain.category.dto.request.CreateCategoryRequestDto;
+import com.spring.mySelectShop.domain.category.dto.request.UpdateCategoryRequestDto;
+import com.spring.mySelectShop.domain.category.entity.Category;
+import com.spring.mySelectShop.domain.category.exception.CategoryExceptionCode;
+import com.spring.mySelectShop.domain.category.exception.custom.CategoryAlreadyExistsException;
+import com.spring.mySelectShop.domain.category.exception.custom.CategoryNotFoundException;
+import com.spring.mySelectShop.domain.category.repository.CategoryRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+
+    private void validateCategoryNameDuplication(String name) {
+        if (categoryRepository.existsByName(name)) {
+            throw new CategoryAlreadyExistsException(name);
+        }
+    }
+
+    public CategoryDto createCategory(CreateCategoryRequestDto requestDto) {
+        validateCategoryNameDuplication(requestDto.name());
+
+        Category category = create(requestDto.name(), requestDto.isActive());
+        categoryRepository.save(category);
+
+        return CategoryDto.fromEntity(category);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CategoryDto> getAllActiveCategories(Integer page, Integer size, String sortBy,
+            Boolean isAsc) {
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, sortBy);
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        Page<Category> categoryPage = categoryRepository.findAllByIsActiveTrue(pageable);
+
+        return categoryPage.map(CategoryDto::fromEntity);
+    }
+
+    @Transactional(readOnly = true)
+    public CategoryDto getCategoryById(UUID id) {
+        Category category = categoryRepository.findById(id).orElseThrow(
+                () -> new CategoryNotFoundException("Category with id: " + id + " not found!"));
+        return CategoryDto.fromEntity(category);
+    }
+
+    @Transactional
+    public CategoryDto deleteCategoryById(UUID id) {
+        Category category = categoryRepository.findById(id).orElseThrow(
+                () -> new CategoryNotFoundException("Category with id: " + id + " not found!"));
+
+        category.update(category.getName(), false);
+        return CategoryDto.fromEntity(category);
+    }
+
+    @Transactional
+    public CategoryDto updateCategoryByName(UUID id, UpdateCategoryRequestDto requestDto) {
+        validateCategoryNameDuplication(requestDto.name());
+
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new CategoryNotFoundException(
+                        CategoryExceptionCode.CATEGORY_NOT_FOUND.getMessage()));
+
+        category.update(requestDto.name(), category.getIsActive());
+        categoryRepository.save(category);
+
+        return CategoryDto.fromEntity(category);
+    }
+
+}


### PR DESCRIPTION
## ✨ 작업 내용
- [x] 이슈 번호: This closes #6 
- [x] 주요 변경 사항을 간략히 설명

스프링 3.3으로 자료를 만들다가 처음 보는 WARN 로그가 보였다.
2024-08-26T15:13:27.588+09:00  WARN 63105 --- [todo] [nio-8080-exec-2] PageModule$PlainPageSerializationWarning : Serializing PageImpl instances as-is is not supported, meaning that there is no guarantee about the stability of the resulting JSON structure!
	For a stable JSON structure, please use Spring Data's PagedModel (globally via @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO))
	or Spring HATEOAS and Spring Data's PagedResourcesAssembler as documented in https://docs.spring.io/spring-data/commons/reference/repositories/core-extensions.html#core.web.pageables.

## 🛠 변경 사항
- [x] 기능 추가 / 수정 / 삭제 설명
- [x] 기존 코드에서 변경된 사항 (가능하면 코드 블록 활용)

예외 메세지만 담당하는 Enum 클래스를 구현한 것처럼,
Validation 메시지만 담당하는 하나의 클래스를 구현했다. enum으로 구현하지 않은 이유는 @notblank, @pattern 등 Validation을 적용한 애너테이션들이 모두 상수만 사용할 수 있기 때문에 class로 관리한다.

dto를 구현하여 엔티티 자체를 반환하지 않고, 필요한 정보를 반환하고, 요청할 수 있도록 구현을 할 것이다.

카테고리만의예외가 발생했을 때 처리할 수 있는 예외를 구현한다. 구현하면서 필요에 따라 앞으로도 계속 추가될 예정이다.

@order 애너테이션으로 글로벌 예외보다 우선 순위를 높게 설정하여 먼저 수행되도록 설정했다. 그러나 내부적으로 @order의 수행은 예측이 불가능하다. 그래서 다른 도메인을 구현할 떄에도 어떻게 될 지 좀 더 지켜보자.

## 🔍 테스트 방법
- [x] 테스트 시나리오 작성 (어떻게 테스트했는지 설명)

## ✅ 체크리스트
- [x] PR 제목이 명확한지 확인
- [x] 코드 스타일 및 포맷팅이 맞는지 확인
- [x] 필요한 경우, 문서(README) 업데이트

## 📸 스크린샷 (선택)
(기능이 UI와 관련되어 있다면 스크린샷 첨부!)

## 🤔 추가 논의 사항 (선택)
- (리뷰어에게 논의가 필요한 부분이 있다면 작성!)